### PR TITLE
Add ability to set root folder in case the opened folder is not the repo root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ A simple VSCode extension to open the current selection in the current file in a
 This extension contributes the following settings:
 
 * `openInAzureDevOps.repoUrl`: **required** The repo url to open the files against
+* `openInAzureDevOps.rootFolder`: **optional** The root folder of your repo. If not provided, gets the relative path of the current open folder.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
 				"openInAzureDevOps.repoUrl": {
 					"description": "Full path to your repo e.g. https://contoso.visualstudio.com/MyTeam/_git/my-repo",
 					"type": "string"
+				},
+				"openInAzureDevOps.rootFolder": {
+					"description": "Root folder of your repo e.g. C:\\src\\my-repo",
+					"type": "string"
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 
 export function activate(context: vscode.ExtensionContext) {
 	let disposable = vscode.commands.registerCommand('extension.openInAzureDevOps', () => {
@@ -6,7 +7,13 @@ export function activate(context: vscode.ExtensionContext) {
 		if (!repoUrl || !vscode.window.activeTextEditor) {
 			return;
 		}
-		const relativePath = '/' + vscode.workspace.asRelativePath(vscode.window.activeTextEditor.document.fileName);
+		let rootFolder: string = vscode.workspace.getConfiguration().get('openInAzureDevOps.rootFolder') || '';
+
+		let relativePath = '/' + vscode.workspace.asRelativePath(vscode.window.activeTextEditor.document.fileName);
+		if (rootFolder != '' && fs.existsSync(rootFolder)) {
+			relativePath = vscode.window.activeTextEditor.document.fileName.replace(rootFolder, '');
+		}
+		
 		let lineStart: number = 0;
 		let columnStart: number = 0;
 		let lineEnd: number = 0;


### PR DESCRIPTION
As mentioned, adding ability to set the root folder, in case opened folder is not the repo root.
Previous functionality should work without any issue, as this check whether the root folder is empty or not.